### PR TITLE
.gitattributes: make sure *.h *.c are detected as C

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c linguist-language=C
+*.h linguist-language=C


### PR DESCRIPTION
Currently [a large portion of your code is detected as Objective C](https://github.com/cathugger/mkp224o/search?l=objective-c), which is incorrect. Use .gitattributes to mark it as C.