### PR TITLE
Add support for pass-phrase seed generation.

### DIFF
--- a/common.h
+++ b/common.h
@@ -13,6 +13,14 @@
 // full onion address, WITHOUT newline
 #define ONION_LEN 62
 
+// How many times we loop before a reseed
+#define DETERMINISTIC_LOOP_COUNT 1<<24
+
+// Argon2 hashed passphrase stretching settings
+#define PWHASH_OPSLIMIT 256
+#define PWHASH_MEMLIMIT 64 * 1024 * 1024
+#define PWHASH_ALG 	crypto_pwhash_ALG_ARGON2ID13
+
 extern pthread_mutex_t fout_mutex;
 extern FILE *fout;
 

--- a/main.c
+++ b/main.c
@@ -1036,6 +1036,9 @@ int main(int argc,char **argv)
 
 	pthread_mutex_destroy(&keysgenerated_mutex);
 	pthread_mutex_destroy(&fout_mutex);
+#ifdef PASSPHRASE
+	pthread_attr_destroy(&determseed_mutex);
+#endif
 
 done:
 	filters_clean();


### PR DESCRIPTION
While passphrases are often seen as weak, vanity in and itself is a strong KDF to stretch the seed bits - adversary needs to redo all the vanity work for each of their attempt to break the passphrase.