### PR TITLE
Fix possible numbers in base32

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ performance-related tips.
 
 * Generate addresses with 1-2 and 7-9 digits?
 
-  Onion addresses use base32 encoding which does not include 1,2,7,8,9
+  Onion addresses use base32 encoding which does not include 0,1,8,9
   numbers.\
   So no, that's not possible to generate these, and mkp224o tries to
   detect invalid filters containing them early on.


### PR DESCRIPTION
The readme stated is is possible to gerenate a 0 and also stated 2 and 7 are not included in the base32 character set... fixed that.