### PR TITLE
Mention nix derivation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Use `-h` switch to obtain all available options.
 I highly recommend reading [OPTIMISATION.txt][OPTIMISATION] for
 performance-related tips.
 
+### Nix
+You can access this software via nix flakes by running `nix run github:JonathanLorimer/mkp224o.nix`
+
 ### FAQ and other useful info
 
 * How do I generate address?


### PR DESCRIPTION
I wrote a quick nix derivation for this project, and it seems to be running fine. You can access it by the nix flake api.

You can find the repo [here](https://github.com/JonathanLorimer/mkp224o.nix)