### PR TITLE
Trustless mining (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ cp out/zzz*.onion/hs_ed25519_secret_key.fixed /var/lib/tor/hidden_service/hs_e
 #### the ugly
 * i'm an amateur, the math might not check out
 * horrible code organization - i'm not familiar with this style of codebases at all
-* depends on ed25519-donna
+* no support for ref10, partial support for supercop amd64
 * only works with slow key generation (-Z)
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ saving to out/zzzkzmpje34nnp2yvgz7slr7rgpajzlpihsr3rpzgmekrjosnpprf2id.onion/hs_
 
 $ cp out/zzz*.onion/hs_ed25519_secret_key.fixed /var/lib/tor/hidden_service/hs_ed25519_secret_key
 ```
+I recommend doing a test run with a short filter before mining "for real". Some settings are currently broken.
 
 #### the ugly
 * i'm an amateur, the math might not check out
 * horrible code organization - i'm not familiar with this style of codebases at all
-* no support for ref10, partial support for supercop amd64
+* no support for ref10
+* no automated tests
 * only works with slow key generation (-Z)
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ done.
 
 $ ./mkp224o -n 1 -d out -Z --basekey out/base.pub zzz
 
-$ ./mkp224o --combine out/base.priv out/zzz*.onion/hs_ed25519_secret_key
+$ ./mkp224o --combine out/zzz*.onion/hs_ed25519_secret_key out/base.priv
 new pk: [...]
 saving to out/zzzkzmpje34nnp2yvgz7slr7rgpajzlpihsr3rpzgmekrjosnpprf2id.onion/hs_ed25519_secret_key.fixed
 
 $ cp out/zzz*.onion/hs_ed25519_secret_key.fixed /var/lib/tor/hidden_service/hs_ed25519_secret_key
 ```
 I recommend doing a test run with a short filter before mining "for real". Some settings are currently broken.
+It's also possible to specify [multiple basekeys](https://github.com/cathugger/mkp224o/issues/60#issuecomment-1305033288).
 
 #### the ugly
 * i'm an amateur, the math might not check out

--- a/README.md
+++ b/README.md
@@ -3,34 +3,6 @@
 This tool generates vanity ed25519 ([hidden service version 3][v3],
 formely known as proposal 224) onion addresses.
 
-### What is this fork?
-This is my shot at implementing [trustless mining](https://github.com/cathugger/mkp224o/issues/60).
-It's a garbage implementation, but it (kinda?) works.
-
-#### Usage
-```
-$ ./mkp224o --genbase out/base.priv out/base.pub
-writing private base key to 'out/base.priv'
-writing public base key to 'out/base.pub'
-done.
-
-$ ./mkp224o -n 1 -d out -Z --basekey out/base.pub zzz
-
-$ ./mkp224o --combine out/zzz*.onion/hs_ed25519_secret_key out/base.priv
-new pk: [...]
-saving to out/zzzkzmpje34nnp2yvgz7slr7rgpajzlpihsr3rpzgmekrjosnpprf2id.onion/hs_ed25519_secret_key.fixed
-
-$ cp out/zzz*.onion/hs_ed25519_secret_key.fixed /var/lib/tor/hidden_service/hs_ed25519_secret_key
-```
-I recommend doing a test run with a short filter before mining "for real". Some settings are currently broken.
-It's also possible to specify [multiple basekeys](https://github.com/cathugger/mkp224o/issues/60#issuecomment-1305033288).
-
-#### the ugly
-* i'm an amateur, the math might not check out
-* horrible code organization - i'm not familiar with this style of codebases at all
-* no support for ref10
-* no automated tests
-
 ### Requirements
 
 * C99 compatible compiler (gcc and clang should work)
@@ -74,6 +46,33 @@ Use `-h` switch to obtain all available options.
 
 I highly recommend reading [OPTIMISATION.txt][OPTIMISATION] for
 performance-related tips.
+
+#### Trustless mining
+[Trustless mining](https://github.com/cathugger/mkp224o/issues/60) lets someone
+else safely mine a vanity .onion for you without letting them get its private
+key. Beware that it's an experimental feature - it's not yet completely tested,
+audited, nor does it work with all configurations.
+
+```
+# example usage
+$ ./mkp224o --genbase base.priv base.pub
+writing private base key to 'base.priv'
+writing public base key to 'base.pub'
+done.
+
+$ ./mkp224o --basekey base.pub -d ~/keys -n 1 neko
+set workdir: /home/dzwdz/keys/
+sorting filters... done.
+filters:
+        neko
+in total, 1 filter
+using 1 thread
+neko3q2neskgkol2gyg2hia46xnavwt4yfy2nvj2pulmvc7lxk6yfkad.onion
+waiting for threads to finish... done.
+
+$ ./mkp224o --combine ~/keys/neko3q2nes*.onion/halfkey base.priv
+saving to ~/keys/neko3q2neskgkol2gyg2hia46xnavwt4yfy2nvj2pulmvc7lxk6yfkad.onion/hs_ed25519_secret_key
+```
 
 ### FAQ and other useful info
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,32 @@
 This tool generates vanity ed25519 ([hidden service version 3][v3],
 formely known as proposal 224) onion addresses.
 
+### What is this fork?
+This is my shot at implementing [trustless mining](https://github.com/cathugger/mkp224o/issues/60).
+It's a garbage implementation, but it (kinda?) works.
+
+#### Usage
+```
+$ ./mkp224o --genbase out/base.priv out/base.pub
+writing private base key to 'out/base.priv'
+writing public base key to 'out/base.pub'
+done.
+
+$ ./mkp224o -n 1 -d out -Z --basekey out/base.pub zzz
+
+$ ./mkp224o --combine out/base.priv out/zzz*.onion/hs_ed25519_secret_key
+new pk: [...]
+saving to out/zzzkzmpje34nnp2yvgz7slr7rgpajzlpihsr3rpzgmekrjosnpprf2id.onion/hs_ed25519_secret_key.fixed
+
+$ cp out/zzz*.onion/hs_ed25519_secret_key.fixed /var/lib/tor/hidden_service/hs_ed25519_secret_key
+```
+
+#### the ugly
+* i'm an amateur, the math might not check out
+* horrible code organization - i'm not familiar with this style of codebases at all
+* depends on ed25519-donna
+* only works with slow key generation (-Z)
+
 ### Requirements
 
 * C99 compatible compiler (gcc and clang should work)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ I recommend doing a test run with a short filter before mining "for real". Some 
 * horrible code organization - i'm not familiar with this style of codebases at all
 * no support for ref10
 * no automated tests
-* only works with slow key generation (-Z)
 
 ### Requirements
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ AC_ARG_ENABLE([ref10],
 	[AS_HELP_STRING([--enable-ref10],
 		[use SUPERCOP ref10 ed25519 implementation @<:@default=no@:>@])],
 	[
+		AC_MSG_ERROR(ref10 is temporarily unsupported. try using donna instead)
 		AS_IF([test x"$ed25519impl" != x"" -a "$ed25519impl" != "ref10"],
 			[AC_MSG_ERROR(only one ed25519 implementation can be defined)])
 		ed25519impl="ref10"

--- a/ed25519/ed25519_impl_pre.h
+++ b/ed25519/ed25519_impl_pre.h
@@ -79,6 +79,7 @@ inline static void ge_initeightpoint(void) {}
 #define ge_p3         ge25519_p3
 #define ge_p1p1_to_p3 ge25519_p1p1_to_p3
 #define ge_p3_tobytes ge25519_pack
+#define ge_frombytes_negate_vartime ge25519_unpackneg_vartime
 #define ge_add        ge25519_pnielsadd_p1p1
 
 #define ge_p3_batchtobytes_destructive_1      ge25519_batchpack_destructive_1
@@ -190,6 +191,7 @@ static int ed25519_keypair(unsigned char *pk,unsigned char *sk)
 
 #define ge_p1p1_to_p3 ge25519_p1p1_to_full
 #define ge_p3_tobytes ge25519_pack
+#define ge_frombytes_negate_vartime ge25519_unpack_negative_vartime
 
 #define ge_p3_batchtobytes_destructive_1      ge25519_batchpack_destructive_1
 #define ge_p3_batchtobytes_destructive_finish ge25519_batchpack_destructive_finish

--- a/ed25519/ed25519_impl_pre.h
+++ b/ed25519/ed25519_impl_pre.h
@@ -186,6 +186,7 @@ static int ed25519_keypair(unsigned char *pk,unsigned char *sk)
 }
 
 #define fe      bignum25519
+#define sc25519 bignum256modm
 #define ge_p1p1 ge25519_p1p1
 #define ge_p3   ge25519
 
@@ -196,10 +197,28 @@ static int ed25519_keypair(unsigned char *pk,unsigned char *sk)
 #define ge_p3_batchtobytes_destructive_1      ge25519_batchpack_destructive_1
 #define ge_p3_batchtobytes_destructive_finish ge25519_batchpack_destructive_finish
 
-
 #define ge_add             CRYPTO_NAMESPACE(ge_add)
 #define ge_scalarmult_base CRYPTO_NAMESPACE(ge_scalarmult_base)
 
+static void sc25519_from32bytes(bignum256modm *r, const unsigned char x[32])
+{
+	expand256_modm(*r, x, 32);
+}
+
+static void sc25519_to32bytes(unsigned char r[32], const sc25519 *x)
+{
+	contract256_modm(r, *x);
+}
+
+static void sc25519_add(bignum256modm *r, const bignum256modm *x, const bignum256modm *y)
+{
+	add256_modm(*r, *x, *y);
+}
+
+static void ge25519_scalarmult_base(ge25519 *r, const bignum256modm *s)
+{
+	ge25519_scalarmult_base_niels(r,ge25519_niels_base_multiples,*s);
+}
 
 DONNA_INLINE static void ge_add(ge25519_p1p1 *r,const ge25519 *p,const ge25519_pniels *q)
 {

--- a/headers.h
+++ b/headers.h
@@ -1,6 +1,8 @@
-// includes the implicit NUL
-#define HEADER_BASESK "mkp224o base_sk"
+#define HEADER_BASESK "mkp224o base_sk\0"
 #define HEADER_BASESKLEN 16
 
-#define HEADER_BASEPK "mkp224o base_pk"
+#define HEADER_BASEPK "mkp224o base_pk\0"
 #define HEADER_BASEPKLEN 16
+
+#define HEADER_HALFKEY "mkp224o halfkey\0"
+#define HEADER_HALFKEYLEN 16

--- a/headers.h
+++ b/headers.h
@@ -1,0 +1,6 @@
+// includes the implicit NUL
+#define HEADER_BASESK "mkp224o base_sk"
+#define HEADER_BASESKLEN 16
+
+#define HEADER_BASEPK "mkp224o base_pk"
+#define HEADER_BASEPKLEN 16

--- a/main.c
+++ b/main.c
@@ -134,7 +134,7 @@ static void printhelp(FILE *out,const char *progname)
 		"                        (may be useful for tor controller API)\n"
 		"  --basekey base.pub\n"
 		"                        trustless mining: the private keys found will need\n"
-		"                        to be --combine'd with thr private parts of all\n"
+		"                        to be --combine'd with the private parts of all\n"
 		"                        basekeys used\n"
 		"  --genbase base.priv base.pub\n"
 		"                        generate base keys for trustless mining\n"

--- a/main.c
+++ b/main.c
@@ -360,15 +360,15 @@ static void combine(const char *privpath, const char *hs_secretkey)
 	// Save secret scalar.
 	sc25519_to32bytes(&secret[32], &a);
 
-	// Compute second half of the key.
+	// Compute the key's hash prefix.
 	// See "Pseudorandom generation of r.", page 8 of https://ed25519.cr.yp.to/ed25519-20110926.pdf
 	// You're supposed to generate it together with the secret scalar, but
 	// we can't really do that here. As far as I can tell, it just needs to
 	// be another secret value.
 	// In normal Ed25519 you never have a pair of keys with the same secret
-	// scalar but different second halves (I can't find the proper term for
-	// it...). If I generated them independently from the secret scalar,
-	// someone could run --combine and get such a pair of keys.
+	// scalar but different hash prefixes. If I generated hash prefixes
+	// independently from the secret scalar (such as by just using random
+	// bytes), you could get such a pair by running --combine multiple times.
 	// I don't know if that would mess anything up, but to err on the side
 	// of caution, I'm setting it to a hash of the secret scalar and the
 	// original generated key.

--- a/main.c
+++ b/main.c
@@ -677,11 +677,6 @@ int main(int argc,char **argv)
 			filters_add(arg);
 	}
 
-	if (deterministic) {
-		fprintf(stderr, "deterministic trustless mining isn't supported yet.\n");
-		exit(1);
-	}
-
 	if (yamlinput && yamloutput) {
 		fprintf(stderr,"both -y and -Y does not make sense\n");
 		exit(1);

--- a/main.c
+++ b/main.c
@@ -659,8 +659,9 @@ int main(int argc,char **argv)
 			filters_add(arg);
 	}
 
-	if (wt != WT_SLOW) {
-		fprintf(stderr,"you're not using -Z. this will probably break.");
+	if (deterministic) {
+		fprintf(stderr, "deterministic trustless mining isn't supported yet.\n");
+		exit(1);
 	}
 
 	if (basekeyfile) {

--- a/main.c
+++ b/main.c
@@ -682,11 +682,6 @@ int main(int argc,char **argv)
 		exit(1);
 	}
 
-	if (basekeys == 0) {
-		fprintf(stderr, "This build requires using --basekey.\n");
-		exit(1);
-	}
-
 	if (yamlinput && yamloutput) {
 		fprintf(stderr,"both -y and -Y does not make sense\n");
 		exit(1);

--- a/main.c
+++ b/main.c
@@ -274,6 +274,7 @@ enum worker_type {
 #include "ed25519/ed25519_impl_pre.h"
 static void genbase(const char *privpath, const char *pubpath)
 {
+#ifdef ED25519_donna
 	u8 base_sk[32];
 	u8 base_pk[32];
 	hash_512bits base_extsk;
@@ -312,10 +313,15 @@ static void genbase(const char *privpath, const char *pubpath)
 	fclose(fp);
 
 	puts("done.");
+#else
+	fprintf(stderr, "Please compile with ed25519-donna to use this flag.\n");
+	exit(1);
+#endif
 }
 
 static void combine(const char *privpath, const char *hs_secretkey)
 {
+#ifdef ED25519_donna
 	u8 base_sk[32], secret[96];
 	FILE *fp;
  
@@ -414,6 +420,10 @@ static void combine(const char *privpath, const char *hs_secretkey)
 		exit(1);
 	}
 	fclose(fp);
+#else
+	fprintf(stderr, "Please compile with ed25519-donna to use this flag.\n");
+	exit(1);
+#endif
 }
 #include "ed25519/ed25519_impl_post.h"
 

--- a/worker.h
+++ b/worker.h
@@ -36,7 +36,7 @@ extern u8 determseed[SEED_LEN];
 #endif
 
 extern void worker_init(void);
-extern void ed25519_pubkey_setbase(const u8 base_pk[32]);
+extern void ed25519_pubkey_addbase(const u8 base_pk[32]);
 
 extern char *makesname(void);
 extern size_t worker_batch_memuse(void);

--- a/worker.h
+++ b/worker.h
@@ -36,6 +36,7 @@ extern u8 determseed[SEED_LEN];
 #endif
 
 extern void worker_init(void);
+extern void ed25519_pubkey_setbase(const u8 base_pk[32]);
 
 extern char *makesname(void);
 extern size_t worker_batch_memuse(void);

--- a/worker_batch.inc.h
+++ b/worker_batch.inc.h
@@ -25,6 +25,9 @@ void *CRYPTO_NAMESPACE(worker_batch)(void *task)
 	(void) task;
 #endif
 
+	if (unlikely(pubkey_base_initialized == 0))
+		abort();
+
 	PREFILTER
 
 	memcpy(secret,skprefix,SKPREFIX_SIZE);
@@ -46,8 +49,8 @@ initseed:
 	randombytes(seed,sizeof(seed));
 
 	ed25519_seckey_expand(sk,seed);
-
 	ge_scalarmult_base(&ge_public,sk);
+	ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
 
 	for (counter = 0;counter < SIZE_MAX-(8*BATCHNUM);counter += 8*BATCHNUM) {
 		ge_p1p1 ALIGN(16) sum;

--- a/worker_batch.inc.h
+++ b/worker_batch.inc.h
@@ -25,9 +25,6 @@ void *CRYPTO_NAMESPACE(worker_batch)(void *task)
 	(void) task;
 #endif
 
-	if (unlikely(pubkey_base_initialized == 0))
-		abort();
-
 	PREFILTER
 
 	memcpy(secret,skprefix,SKPREFIX_SIZE);
@@ -50,7 +47,9 @@ initseed:
 
 	ed25519_seckey_expand(sk,seed);
 	ge_scalarmult_base(&ge_public,sk);
-	ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
+	if (pubkey_base_initialized) {
+		ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
+	}
 
 	for (counter = 0;counter < SIZE_MAX-(8*BATCHNUM);counter += 8*BATCHNUM) {
 		ge_p1p1 ALIGN(16) sum;

--- a/worker_batch_pass.inc.h
+++ b/worker_batch_pass.inc.h
@@ -54,6 +54,9 @@ initseed:
 	ed25519_seckey_expand(sk,seed);
 
 	ge_scalarmult_base(&ge_public,sk);
+	if (pubkey_base_initialized) {
+		ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
+	}
 
 	for (counter = oldcounter = 0;counter < DETERMINISTIC_LOOP_COUNT - (BATCHNUM - 1) * 8;counter += BATCHNUM * 8) {
 		ge_p1p1 ALIGN(16) sum;

--- a/worker_fast.inc.h
+++ b/worker_fast.inc.h
@@ -41,8 +41,8 @@ initseed:
 	randombytes(seed,sizeof(seed));
 
 	ed25519_seckey_expand(sk,seed);
-
 	ge_scalarmult_base(&ge_public,sk);
+	ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
 	ge_p3_tobytes(pk,&ge_public);
 
 	for (counter = 0;counter < SIZE_MAX-8;counter += 8) {

--- a/worker_fast.inc.h
+++ b/worker_fast.inc.h
@@ -42,7 +42,9 @@ initseed:
 
 	ed25519_seckey_expand(sk,seed);
 	ge_scalarmult_base(&ge_public,sk);
-	ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
+	if (pubkey_base_initialized) {
+		ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
+	}
 	ge_p3_tobytes(pk,&ge_public);
 
 	for (counter = 0;counter < SIZE_MAX-8;counter += 8) {

--- a/worker_fast_pass.inc.h
+++ b/worker_fast_pass.inc.h
@@ -49,6 +49,9 @@ initseed:
 	ed25519_seckey_expand(sk,seed);
 
 	ge_scalarmult_base(&ge_public,sk);
+	if (pubkey_base_initialized) {
+		ge25519_add(&ge_public, &ge_public, &PUBKEY_BASE);
+	}
 	ge_p3_tobytes(pk,&ge_public);
 
 	for (counter = oldcounter = 0;counter < DETERMINISTIC_LOOP_COUNT;counter += 8) {

--- a/worker_impl.inc.h
+++ b/worker_impl.inc.h
@@ -12,4 +12,4 @@ static size_t CRYPTO_NAMESPACE(worker_batch_memuse)(void)
 #include "worker_batch.inc.h"
 #include "worker_batch_pass.inc.h"
 
-#include "ed25519/ed25519_impl_post.h"
+// #include "ed25519/ed25519_impl_post.h"

--- a/worker_impl.inc.h
+++ b/worker_impl.inc.h
@@ -1,6 +1,4 @@
 
-#include "ed25519/ed25519_impl_pre.h"
-
 static size_t CRYPTO_NAMESPACE(worker_batch_memuse)(void)
 {
 	return (sizeof(ge_p3) + sizeof(fe) + sizeof(bytes32)) * BATCHNUM;
@@ -12,4 +10,3 @@ static size_t CRYPTO_NAMESPACE(worker_batch_memuse)(void)
 #include "worker_batch.inc.h"
 #include "worker_batch_pass.inc.h"
 
-// #include "ed25519/ed25519_impl_post.h"

--- a/worker_slow.inc.h
+++ b/worker_slow.inc.h
@@ -42,7 +42,7 @@ again:
 	if (unlikely(endwork))
 		goto end;
 
-	ed25519_pubkey(pk,sk);
+	ed25519_pubkey_onbase(pk,sk);
 
 #ifdef STATISTICS
 	++st->numcalc.v;


### PR DESCRIPTION
Solves #60.
It's not really mergeable yet. The current issues are:
* I only tested this on Alpine Linux, and didn't exhaustively check all configurations for possible regressions etc.
* I had to disable ref10 support, because it lacked some essential functions iirc. Hopefully this won't be too big of an issue, as ed25519-donna should be a complete replacement? Maybe? Are there systems where it doesn't run?
* I had to pull in `ed25519_impl_{pre,post}.h` in `main.c`, which is pretty horrible.
* Nobody else looked at the crypto yet but me - I *think* the math checks out, but you shouldn't rely just on me.

I tried to make it somewhat idiotproof by ensuring you won't get a private key that'll work with Tor unless you did everything right. I did not protect against someone using the same base key for multiple .onions - maybe I could add a disclaimer when using `--combine` if you think that's necessary.

Thanks in advance for any feedback ^^